### PR TITLE
fix multi regex matching rules for a single domain

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,5 +14,5 @@
    "options_page": "switcheroo.html?flags=options",
    "permissions": [ "webRequest", "webRequestBlocking", "\u003Call_urls>", "tabs" ],
    "update_url": "http://clients2.google.com/service/update2/crx",
-   "version": "1.0"
+   "version": "1.0.1"
 }

--- a/src/request.js
+++ b/src/request.js
@@ -11,17 +11,17 @@ else{
 
 chrome.webRequest.onBeforeRequest.addListener(function(details) {
 	return redirectToMatchingRule(details);
-}, {
-	urls : ["<all_urls>"]
-}, ["blocking"]);
+}, 
+{urls : ["<all_urls>"]}, ["blocking"]);
 
 function redirectToMatchingRule(details) {
+	
 	for (var i = 0; i < rules.length; i++) {
 		var rule = rules[i];
 		var sURL = details.url;
 
 		if (rule.isRegex) {
-			if (rule.isActive && details.requestId !== lastRequestId) {
+			if (rule.isActive ) {
 				lastRequestId = details.requestId;
 
 				if (rule.from.substring(0,1) == "/") {
@@ -35,8 +35,10 @@ function redirectToMatchingRule(details) {
 				}
 				
 				if (sURL.match(regx)) {
+					console.log('got a match', sURL);
 					sURL = sURL.replace(regx, rule.to);
 					details.url = sURL;
+					
 					return{
 						redirectUrl : details.url
 					};


### PR DESCRIPTION
When multiple regex rules are specified for a single domain only the first matching regex rule in the list is replaced. Ideally each URL request should be matched. This issue appeared after updating to Chrome 55+ and is persistent throughout 55+ versions.

This is a rough patch that fixes the issue without touching surrounding code (on the basis that the maintainer would review and suggest feedback based on the intent of the logic). 

It seems that the logic for `lastRequestId`  is used to prevent re-processing of already processed requests however that doesn't seem to happen in Chrome based on initial testing. Additionally this seems inconsistent with the examples provided on MDN and Chrome API docs which async process all url requests 

[MDN WebRequest docs](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webRequest/onBeforeRequest)
[Chrome webRequest API docs](https://developer.chrome.com/extensions/webRequest)